### PR TITLE
feat: add thermal ticket printing on NYX POS after payment

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.CAMERA" />
+     <queries>
+        <package android:name="net.nyx.printerservice"/>
+    </queries>
     <application
         android:label="treintaypico"
         android:name="${applicationName}"

--- a/lib/features/orders/data/services/ticket_printer_service.dart
+++ b/lib/features/orders/data/services/ticket_printer_service.dart
@@ -1,0 +1,130 @@
+// EVNTS POS — Servicio de impresión de tickets/recibos para pedidos.
+// Usa nyx_printer_v2 para generar tickets físicos (impresora térmica) con
+// cabecera, QR del pedido, detalle de ítems y total.
+
+import 'package:nyx_printer_v2/nyx_printer.dart';
+import 'package:treintaypico/features/orders/domain/entities/order_entity.dart';
+
+/// Servicio que genera e imprime el ticket de un pedido en impresora térmica.
+/// Formato: cabecera EVNTS POS, número de pedido, QR, cliente, fecha, método de pago,
+/// detalle de ítems y total. Retorna [true] si la impresión fue exitosa.
+class TicketPrinterService {
+  static const int _lineWidth = 32;
+  static const String _separator = '--------------------------------';
+  static const String _separatorDouble = '================================';
+
+  final NyxPrinter _printer = NyxPrinter();
+
+  /// Imprime el ticket del pedido. Retorna true si fue exitoso.
+  Future<bool> printTicket(OrderEntity order) async {
+      try {
+        // 1. Header: "EVNTS POS" — center, bold, size 36
+        await _printer.printText('EVNTS POS', textFormat: NyxTextFormat(
+          textSize: 36,
+          align: NyxAlign.center,
+          style: NyxFontStyle.bold,
+        ));
+
+        // 2. Order number — center, size 18
+        await _printer.printText('Order #${order.orderNumber}', textFormat: NyxTextFormat(
+          textSize: 18,
+          align: NyxAlign.center,
+        ));
+
+        // 3. Separador
+        await _printer.printText(_separator, textFormat: NyxTextFormat(
+          align: NyxAlign.center,
+        ));
+
+        // 4. QR Code del order number
+        await _printer.printQrCode(order.orderNumber, width: 250, height: 250);
+
+        // 5. Info cliente — center, size 16/14
+        await _printer.printText('Cliente: ${order.userName}', textFormat: NyxTextFormat(
+          textSize: 16,
+          align: NyxAlign.center,
+        ));
+
+        // 6. Fecha (momento del pago)
+        final date = order.updatedAt;
+        final dateStr = '${date.day.toString().padLeft(2, '0')}/${date.month.toString().padLeft(2, '0')}/${date.year} ${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}';
+        await _printer.printText('Fecha: $dateStr', textFormat: NyxTextFormat(
+          textSize: 14,
+          align: NyxAlign.center,
+        ));
+
+        // 7. Método de pago
+        await _printer.printText('Pagado: ${_paymentMethodLabel(order.paymentMethod)}', textFormat: NyxTextFormat(
+          textSize: 14,
+          align: NyxAlign.center,
+        ));
+
+        // 8. Separador doble
+        await _printer.printText(_separatorDouble, textFormat: NyxTextFormat(
+          align: NyxAlign.center,
+        ));
+
+        // 9. Título items — center, bold
+        await _printer.printText('Detalle del Pedido', textFormat: NyxTextFormat(
+          textSize: 16,
+          align: NyxAlign.center,
+          style: NyxFontStyle.bold,
+        ));
+
+        // 10. Loop items: nombre + precio (alineado a _lineWidth)
+        for (final item in order.items) {
+          final name = item.productName;
+          final price = '\$${item.subtotal.toStringAsFixed(3)}';
+          final padding = _lineWidth - name.length - price.length;
+          final spaces = padding > 0 ? ' ' * padding : ' ';
+          await _printer.printText('$name$spaces$price', textFormat: NyxTextFormat(
+            textSize: 16,
+          ));
+        }
+
+        // 11. Separador
+        await _printer.printText(_separator, textFormat: NyxTextFormat(
+          align: NyxAlign.center,
+        ));
+
+        // 12. TOTAL label
+        await _printer.printText('TOTAL', textFormat: NyxTextFormat(
+          textSize: 14,
+          align: NyxAlign.center,
+        ));
+
+        // 13. Total amount — center, bold, big
+        await _printer.printText('\$${order.totalAmount.toStringAsFixed(3)}', textFormat: NyxTextFormat(
+          textSize: 38,
+          align: NyxAlign.center,
+          style: NyxFontStyle.bold,
+        ));
+
+        // 14. Items count
+        await _printer.printText('${order.items.length} items', textFormat: NyxTextFormat(
+          textSize: 14,
+          align: NyxAlign.center,
+        ));
+
+        // 15. Espacio final (feed paper)
+        await _printer.printText('\n\n\n');
+
+        return true;
+      } catch (e) {
+        return false;
+      }
+  }
+
+  static String _paymentMethodLabel(PaymentMethod? method) {
+    switch (method) {
+      case PaymentMethod.cash:
+        return 'Efectivo';
+      case PaymentMethod.card:
+        return 'Tarjeta';
+      case PaymentMethod.transfer:
+        return 'Transferencia';
+      case null:
+        return 'Efectivo';
+    }
+  }
+}

--- a/lib/features/orders/presentation/screens/order_screen.dart
+++ b/lib/features/orders/presentation/screens/order_screen.dart
@@ -8,6 +8,7 @@ import 'package:treintaypico/features/orders/presentation/widgets/order_detail.d
 import 'package:go_router/go_router.dart';
 import 'package:treintaypico/features/auth/application/providers/auth_providers.dart';
 import 'package:treintaypico/features/orders/presentation/screens/qr_scanner_screen.dart';
+import 'package:treintaypico/features/orders/data/services/ticket_printer_service.dart';
 
 class OrderScreen extends ConsumerStatefulWidget {
   static const name = 'order-screen';
@@ -21,6 +22,7 @@ class OrderScreen extends ConsumerStatefulWidget {
 class _OrderScreenState extends ConsumerState<OrderScreen> {
   final TextEditingController _idController = TextEditingController();
   final FocusNode _searchFocusNode = FocusNode();
+  OrderEntity? _lastOrder;
 
   @override
   void dispose() {
@@ -71,9 +73,19 @@ class _OrderScreenState extends ConsumerState<OrderScreen> {
     final controller = ref.read(orderControllerProvider.notifier);
 
     // Auto-reset después de Success
-    ref.listen<OrderState>(orderControllerProvider, (previous, next) {
+    ref.listen<OrderState>(orderControllerProvider, (previous, next) async {
       if (next is OrderSuccess) {
         _idController.clear();
+        //printer ticket 
+        if (_lastOrder != null) {
+          final printed = await TicketPrinterService().printTicket(_lastOrder!);
+          if (!printed && mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('No se pudo imprimir el ticket')),
+            );
+          }
+          _lastOrder = null;
+      }
         Future.delayed(const Duration(seconds: 5), () {
           if (mounted) {
             controller.resetState();
@@ -174,8 +186,9 @@ class _OrderScreenState extends ConsumerState<OrderScreen> {
                   MaterialPageRoute(builder: (_) => const QrScannerScreen()), 
                 );
                 if(result != null){
-                   _idController.text = result;
-                    controller.fetchOrderById(result);
+                  final scannedValue = result.trim();
+                  _idController.text = scannedValue;
+                  controller.fetchOrderById(scannedValue);
                 }
               },
             ),
@@ -425,6 +438,7 @@ class _OrderScreenState extends ConsumerState<OrderScreen> {
             height: 68,
             child: ElevatedButton(
               onPressed: () {
+                _lastOrder = order;
                 controller.markAsPaid(
                   orderId: order.id,
                   paymentMethod: 'cash',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -296,6 +296,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.2.0"
+  nyx_printer_v2:
+    dependency: "direct main"
+    description:
+      name: nyx_printer_v2
+      sha256: d62852d6340557a02977fbc541923c7ebcc51948179c869efa3a588fbdaf1b2d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   cloud_firestore: ^5.6.5
   firebase_auth: ^5.5.1
   mobile_scanner: ^7.0.0
+  nyx_printer_v2: ^1.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Add nyx_printer_v2 package for built-in thermal printer (Symcode MJ-Q50)
- Add AndroidManifest queries for net.nyx.printerservice AIDL
- Create TicketPrinterService with full receipt layout (header, QR, items, total)
- Connect printing to payment flow: prints ticket after successful markAsPaid
- Show SnackBar error "No se pudo imprimir el ticket" on print failure
- Fix QR scanner result trimming to remove trailing characters